### PR TITLE
chore(perf): fast regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // eslint-disable-next-line
-const strEscapeSequencesRegExp = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]|[\ud800-\udbff](?![\udc00-\udfff])|(?:[^\ud800-\udbff]|^)[\udc00-\udfff]/
+const strEscapeSequencesRegExp = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]/
 
 function strEscape (str) {
   if (typeof str !== 'string') {


### PR DESCRIPTION
The first part of regex alternation will match anything that might have been matched by the second and third parts. This version is much faster.

benchmark
```
NEW 96K ops/s ± 8.44%
OLD 82K ops/s ± 8.23% (14.57 % slower)
```

see: https://github.com/BridgeAR/fast-json-escape/issues/5